### PR TITLE
Refactor: Replace operator `invoke` with `execute` in use case classes

### DIFF
--- a/src/main/kotlin/domain/customer/CustomerRoutes.kt
+++ b/src/main/kotlin/domain/customer/CustomerRoutes.kt
@@ -25,6 +25,7 @@ fun Application.customerRoutes() {
             post {
                 val customer = call.receive<Customer>()
                 val createdCustomer = service.createCustomer(customer.name)
+                println(createdCustomer)
                 call.respond(HttpStatusCode.Created, createdCustomer)
             }
 
@@ -66,6 +67,7 @@ fun Application.customerRoutes() {
                     "Missing or malformed id",
                     status = HttpStatusCode.BadRequest
                 )
+                println(id)
 
                 val note = call.receive<Note>()
                 val updatedCustomer = service.addNote(CustomerId(id), note)

--- a/src/main/kotlin/domain/customer/CustomerService.kt
+++ b/src/main/kotlin/domain/customer/CustomerService.kt
@@ -4,8 +4,6 @@ import com.example.domain.customer.usecases.AddContactUseCase
 import com.example.domain.customer.usecases.AddNoteUseCase
 import com.example.domain.customer.usecases.CreateCustomerUseCase
 import com.example.domain.customer.usecases.GetCustomerUseCase
-import com.example.events.ContactAddedEvent
-import com.example.events.NoteAddedEvent
 import events.EventPublisher
 
 class CustomerService(
@@ -13,12 +11,12 @@ class CustomerService(
     private val eventPublisher: EventPublisher
 ) {
 
-    fun createCustomer(name: String): Customer  = CreateCustomerUseCase(customerRepository).invoke(name)
+    fun createCustomer(name: String): Customer  = CreateCustomerUseCase(customerRepository).execute(name)
 
-    fun getCustomer(id: Long): Customer? = GetCustomerUseCase(customerRepository).invoke(id)
+    fun getCustomer(id: Long): Customer? = GetCustomerUseCase(customerRepository).execute(id)
 
     fun addContact(customerId: CustomerId, contact: Contact):
-            Customer?  = AddContactUseCase(customerRepository, eventPublisher).invoke(customerId,contact)
+            Customer?  = AddContactUseCase(customerRepository, eventPublisher).execute(customerId,contact)
 
-    fun addNote(customerId: CustomerId, note: Note): Customer? = AddNoteUseCase(customerRepository,eventPublisher).invoke(customerId,note)
+    fun addNote(customerId: CustomerId, note: Note): Customer? = AddNoteUseCase(customerRepository,eventPublisher).execute(customerId,note)
 }

--- a/src/main/kotlin/domain/customer/CustomerService.kt
+++ b/src/main/kotlin/domain/customer/CustomerService.kt
@@ -1,5 +1,9 @@
 package com.example.domain.customer
 
+import com.example.domain.customer.usecases.AddContactUseCase
+import com.example.domain.customer.usecases.AddNoteUseCase
+import com.example.domain.customer.usecases.CreateCustomerUseCase
+import com.example.domain.customer.usecases.GetCustomerUseCase
 import com.example.events.ContactAddedEvent
 import com.example.events.NoteAddedEvent
 import events.EventPublisher
@@ -9,41 +13,12 @@ class CustomerService(
     private val eventPublisher: EventPublisher
 ) {
 
-    fun createCustomer(name: String): Customer {
-        val customer = Customer(name = name)
-        customerRepository.save(customer)
-        return customer
-    }
+    fun createCustomer(name: String): Customer  = CreateCustomerUseCase(customerRepository).invoke(name)
 
-    fun getCustomer(id: Long): Customer? {
-        return customerRepository.findById(CustomerId(id))
-    }
+    fun getCustomer(id: Long): Customer? = GetCustomerUseCase(customerRepository).invoke(id)
 
-    fun addContact(customerId: CustomerId, contact: Contact): Customer? {
-        val customer = customerRepository.findById(customerId)
-            ?: return null
+    fun addContact(customerId: CustomerId, contact: Contact):
+            Customer?  = AddContactUseCase(customerRepository, eventPublisher).invoke(customerId,contact)
 
-        // Business logic to add a contact (could be a method on Customer entity)
-        val updatedCustomer = customer.withContact(contact)
-        customerRepository.save(updatedCustomer)
-
-        // Publish a domain event to signal that a new contact has been added
-        eventPublisher.publish(ContactAddedEvent(customerId, contact))
-
-        return updatedCustomer
-    }
-
-
-    fun addNote(customerId: CustomerId, note: Note): Customer? {
-        val customer = customerRepository.findById(customerId)
-            ?: return null
-
-        val updatedCustomer = customer.withNote(note)
-        customerRepository.save(updatedCustomer)
-
-        // Publish a domain event to signal about a new note
-        eventPublisher.publish(NoteAddedEvent(customerId, note))
-
-        return updatedCustomer
-    }
+    fun addNote(customerId: CustomerId, note: Note): Customer? = AddNoteUseCase(customerRepository,eventPublisher).invoke(customerId,note)
 }

--- a/src/main/kotlin/domain/customer/usecases/AddContactUseCase.kt
+++ b/src/main/kotlin/domain/customer/usecases/AddContactUseCase.kt
@@ -11,7 +11,7 @@ class AddContactUseCase(
     private val customerRepository: CustomerRepository,
     private val eventPublisher: EventPublisher
 ) {
-    operator fun invoke(customerId: CustomerId, contact: Contact):Customer?{
+    fun execute(customerId: CustomerId, contact: Contact):Customer?{
         val customer = customerRepository.findById(customerId)
             ?: return null
 

--- a/src/main/kotlin/domain/customer/usecases/AddContactUseCase.kt
+++ b/src/main/kotlin/domain/customer/usecases/AddContactUseCase.kt
@@ -1,0 +1,27 @@
+package com.example.domain.customer.usecases
+
+import com.example.domain.customer.Contact
+import com.example.domain.customer.Customer
+import com.example.domain.customer.CustomerId
+import com.example.domain.customer.CustomerRepository
+import com.example.events.ContactAddedEvent
+import events.EventPublisher
+
+class AddContactUseCase(
+    private val customerRepository: CustomerRepository,
+    private val eventPublisher: EventPublisher
+) {
+    operator fun invoke(customerId: CustomerId, contact: Contact):Customer?{
+        val customer = customerRepository.findById(customerId)
+            ?: return null
+
+        // Business logic to add a contact (could be a method on Customer entity)
+        val updatedCustomer = customer.withContact(contact)
+        customerRepository.save(updatedCustomer)
+
+        // Publish a domain event to signal that a new contact has been added
+        eventPublisher.publish(ContactAddedEvent(customerId, contact))
+
+        return updatedCustomer
+    }
+}

--- a/src/main/kotlin/domain/customer/usecases/AddNoteUseCase.kt
+++ b/src/main/kotlin/domain/customer/usecases/AddNoteUseCase.kt
@@ -1,0 +1,24 @@
+package com.example.domain.customer.usecases
+
+import com.example.domain.customer.*
+import com.example.events.ContactAddedEvent
+import com.example.events.NoteAddedEvent
+import events.EventPublisher
+
+class AddNoteUseCase(
+    private val customerRepository: CustomerRepository,
+    private val eventPublisher: EventPublisher
+) {
+    operator fun invoke(customerId: CustomerId, note: Note):Customer?{
+        val customer = customerRepository.findById(customerId)
+            ?: return null
+
+        val updatedCustomer = customer.withNote(note)
+        customerRepository.save(updatedCustomer)
+
+        // Publish a domain event to signal about a new note
+        eventPublisher.publish(NoteAddedEvent(customerId, note))
+
+        return updatedCustomer
+    }
+}

--- a/src/main/kotlin/domain/customer/usecases/AddNoteUseCase.kt
+++ b/src/main/kotlin/domain/customer/usecases/AddNoteUseCase.kt
@@ -1,7 +1,6 @@
 package com.example.domain.customer.usecases
 
 import com.example.domain.customer.*
-import com.example.events.ContactAddedEvent
 import com.example.events.NoteAddedEvent
 import events.EventPublisher
 
@@ -9,7 +8,7 @@ class AddNoteUseCase(
     private val customerRepository: CustomerRepository,
     private val eventPublisher: EventPublisher
 ) {
-    operator fun invoke(customerId: CustomerId, note: Note):Customer?{
+    fun execute(customerId: CustomerId, note: Note):Customer?{
         val customer = customerRepository.findById(customerId)
             ?: return null
 

--- a/src/main/kotlin/domain/customer/usecases/CreateCustomerUseCase.kt
+++ b/src/main/kotlin/domain/customer/usecases/CreateCustomerUseCase.kt
@@ -1,0 +1,17 @@
+package com.example.domain.customer.usecases
+
+import com.example.domain.customer.Customer
+import com.example.domain.customer.CustomerId
+import com.example.domain.customer.CustomerRepository
+import events.EventPublisher
+import kotlin.uuid.Uuid
+
+class CreateCustomerUseCase(
+    private val customerRepository: CustomerRepository,
+) {
+    operator fun invoke(name:String):Customer{
+        val customer = Customer(name = name, id = CustomerId(value = (1000_000_000..1_899_999_999_999).random()))
+        customerRepository.save(customer)
+        return customer
+    }
+}

--- a/src/main/kotlin/domain/customer/usecases/CreateCustomerUseCase.kt
+++ b/src/main/kotlin/domain/customer/usecases/CreateCustomerUseCase.kt
@@ -3,13 +3,11 @@ package com.example.domain.customer.usecases
 import com.example.domain.customer.Customer
 import com.example.domain.customer.CustomerId
 import com.example.domain.customer.CustomerRepository
-import events.EventPublisher
-import kotlin.uuid.Uuid
 
 class CreateCustomerUseCase(
     private val customerRepository: CustomerRepository,
 ) {
-    operator fun invoke(name:String):Customer{
+    fun execute(name:String):Customer{
         val customer = Customer(name = name, id = CustomerId(value = (1000_000_000..1_899_999_999_999).random()))
         customerRepository.save(customer)
         return customer

--- a/src/main/kotlin/domain/customer/usecases/GetCustomerUseCase.kt
+++ b/src/main/kotlin/domain/customer/usecases/GetCustomerUseCase.kt
@@ -1,0 +1,17 @@
+package com.example.domain.customer.usecases
+
+import com.example.domain.customer.Customer
+import com.example.domain.customer.CustomerId
+import com.example.domain.customer.CustomerRepository
+import events.EventPublisher
+
+class GetCustomerUseCase(
+    private val customerRepository: CustomerRepository,
+) {
+
+    operator fun invoke(id: Long): Customer? {
+        val customerId = CustomerId(id)
+        return customerRepository.findById(customerId)
+    }
+
+}

--- a/src/main/kotlin/domain/customer/usecases/GetCustomerUseCase.kt
+++ b/src/main/kotlin/domain/customer/usecases/GetCustomerUseCase.kt
@@ -3,13 +3,12 @@ package com.example.domain.customer.usecases
 import com.example.domain.customer.Customer
 import com.example.domain.customer.CustomerId
 import com.example.domain.customer.CustomerRepository
-import events.EventPublisher
 
 class GetCustomerUseCase(
     private val customerRepository: CustomerRepository,
 ) {
 
-    operator fun invoke(id: Long): Customer? {
+    fun execute(id: Long): Customer? {
         val customerId = CustomerId(id)
         return customerRepository.findById(customerId)
     }

--- a/src/main/kotlin/domain/reminder/ReminderService.kt
+++ b/src/main/kotlin/domain/reminder/ReminderService.kt
@@ -1,12 +1,10 @@
 package com.example.domain.reminder
 
 import com.example.domain.customer.CustomerId
-import com.example.domain.customer.NoteId
 import com.example.domain.reminder.usecases.CreateReminderUseCase
 import com.example.domain.reminder.usecases.GetReminderForCustomerUseCase
 import com.example.domain.reminder.usecases.GetReminderUseCase
 import domain.reminder.Reminder
-import domain.reminder.ReminderId
 import domain.reminder.ReminderRepository
 import java.time.LocalDateTime
 
@@ -14,9 +12,9 @@ import java.time.LocalDateTime
 class ReminderService(private val reminderRepository: ReminderRepository) {
 
     fun createReminder(customerId: CustomerId, noteId: Long?, remindAt: LocalDateTime, message: String)
-    : Reminder = CreateReminderUseCase(reminderRepository).invoke(customerId, noteId, remindAt, message)
+    : Reminder = CreateReminderUseCase(reminderRepository).execute(customerId, noteId, remindAt, message)
 
-    fun getReminder(id: Long): Reminder? = GetReminderUseCase(reminderRepository).invoke(id)
+    fun getReminder(id: Long): Reminder? = GetReminderUseCase(reminderRepository).execute(id)
 
-    fun getRemindersForCustomer(customerId: CustomerId): List<Reminder> = GetReminderForCustomerUseCase(reminderRepository).invoke(customerId)
+    fun getRemindersForCustomer(customerId: CustomerId): List<Reminder> = GetReminderForCustomerUseCase(reminderRepository).execute(customerId)
 }

--- a/src/main/kotlin/domain/reminder/ReminderService.kt
+++ b/src/main/kotlin/domain/reminder/ReminderService.kt
@@ -2,6 +2,9 @@ package com.example.domain.reminder
 
 import com.example.domain.customer.CustomerId
 import com.example.domain.customer.NoteId
+import com.example.domain.reminder.usecases.CreateReminderUseCase
+import com.example.domain.reminder.usecases.GetReminderForCustomerUseCase
+import com.example.domain.reminder.usecases.GetReminderUseCase
 import domain.reminder.Reminder
 import domain.reminder.ReminderId
 import domain.reminder.ReminderRepository
@@ -10,22 +13,10 @@ import java.time.LocalDateTime
 // ReminderService encapsulates the business logic for creating and retrieving reminders.
 class ReminderService(private val reminderRepository: ReminderRepository) {
 
-    fun createReminder(customerId: CustomerId, noteId: Long?, remindAt: LocalDateTime, message: String): Reminder {
-        val reminder = Reminder(
-            customerId = customerId,
-            noteId = noteId?.let { NoteId(it) },
-            remindAt = remindAt,
-            message = message
-        )
-        reminderRepository.save(reminder)
-        return reminder
-    }
+    fun createReminder(customerId: CustomerId, noteId: Long?, remindAt: LocalDateTime, message: String)
+    : Reminder = CreateReminderUseCase(reminderRepository).invoke(customerId, noteId, remindAt, message)
 
-    fun getReminder(id: Long): Reminder? {
-        return reminderRepository.findById(ReminderId(id))
-    }
+    fun getReminder(id: Long): Reminder? = GetReminderUseCase(reminderRepository).invoke(id)
 
-    fun getRemindersForCustomer(customerId: CustomerId): List<Reminder> {
-        return reminderRepository.findByContact(customerId)
-    }
+    fun getRemindersForCustomer(customerId: CustomerId): List<Reminder> = GetReminderForCustomerUseCase(reminderRepository).invoke(customerId)
 }

--- a/src/main/kotlin/domain/reminder/usecases/CreateReminderUseCase.kt
+++ b/src/main/kotlin/domain/reminder/usecases/CreateReminderUseCase.kt
@@ -10,7 +10,7 @@ import java.time.LocalDateTime
 class CreateReminderUseCase(
     private val reminderRepository: ReminderRepository
 ) {
-    operator fun invoke(customerId: CustomerId, noteId: Long?, remindAt: LocalDateTime, message: String):Reminder{
+    fun execute(customerId: CustomerId, noteId: Long?, remindAt: LocalDateTime, message: String): Reminder {
         val reminder = Reminder(
             id = ReminderId(value = (1000_000_000..1_899_999_999_999).random()),
             customerId = customerId,
@@ -22,3 +22,4 @@ class CreateReminderUseCase(
         return reminder
     }
 }
+

--- a/src/main/kotlin/domain/reminder/usecases/CreateReminderUseCase.kt
+++ b/src/main/kotlin/domain/reminder/usecases/CreateReminderUseCase.kt
@@ -1,0 +1,24 @@
+package com.example.domain.reminder.usecases
+
+import com.example.domain.customer.CustomerId
+import com.example.domain.customer.NoteId
+import domain.reminder.Reminder
+import domain.reminder.ReminderId
+import domain.reminder.ReminderRepository
+import java.time.LocalDateTime
+
+class CreateReminderUseCase(
+    private val reminderRepository: ReminderRepository
+) {
+    operator fun invoke(customerId: CustomerId, noteId: Long?, remindAt: LocalDateTime, message: String):Reminder{
+        val reminder = Reminder(
+            id = ReminderId(value = (1000_000_000..1_899_999_999_999).random()),
+            customerId = customerId,
+            noteId = noteId?.let { NoteId(it) },
+            remindAt = remindAt,
+            message = message
+        )
+        reminderRepository.save(reminder)
+        return reminder
+    }
+}

--- a/src/main/kotlin/domain/reminder/usecases/GetReminderForCustomerUseCase.kt
+++ b/src/main/kotlin/domain/reminder/usecases/GetReminderForCustomerUseCase.kt
@@ -1,15 +1,12 @@
 package com.example.domain.reminder.usecases
 
 import com.example.domain.customer.CustomerId
-import com.example.domain.customer.NoteId
 import domain.reminder.Reminder
-import domain.reminder.ReminderId
 import domain.reminder.ReminderRepository
-import java.time.LocalDateTime
 
 class GetReminderForCustomerUseCase(
     private val reminderRepository: ReminderRepository
 ) {
-    operator fun invoke(customerId: CustomerId):List<Reminder> =  reminderRepository.findByContact(customerId)
+    fun execute(customerId: CustomerId):List<Reminder> =  reminderRepository.findByContact(customerId)
 
 }

--- a/src/main/kotlin/domain/reminder/usecases/GetReminderForCustomerUseCase.kt
+++ b/src/main/kotlin/domain/reminder/usecases/GetReminderForCustomerUseCase.kt
@@ -1,0 +1,15 @@
+package com.example.domain.reminder.usecases
+
+import com.example.domain.customer.CustomerId
+import com.example.domain.customer.NoteId
+import domain.reminder.Reminder
+import domain.reminder.ReminderId
+import domain.reminder.ReminderRepository
+import java.time.LocalDateTime
+
+class GetReminderForCustomerUseCase(
+    private val reminderRepository: ReminderRepository
+) {
+    operator fun invoke(customerId: CustomerId):List<Reminder> =  reminderRepository.findByContact(customerId)
+
+}

--- a/src/main/kotlin/domain/reminder/usecases/GetReminderUseCase.kt
+++ b/src/main/kotlin/domain/reminder/usecases/GetReminderUseCase.kt
@@ -1,16 +1,12 @@
 package com.example.domain.reminder.usecases
 
-import com.example.domain.customer.CustomerId
-import com.example.domain.customer.NoteId
 import domain.reminder.Reminder
 import domain.reminder.ReminderId
 import domain.reminder.ReminderRepository
-import java.time.LocalDateTime
 
 class GetReminderUseCase(
     private val reminderRepository: ReminderRepository
 ) {
-    operator fun invoke(id: Long)
-    :Reminder? = reminderRepository.findById(ReminderId(id))
+    fun execute(id: Long):Reminder? = reminderRepository.findById(ReminderId(id))
 
 }

--- a/src/main/kotlin/domain/reminder/usecases/GetReminderUseCase.kt
+++ b/src/main/kotlin/domain/reminder/usecases/GetReminderUseCase.kt
@@ -1,0 +1,16 @@
+package com.example.domain.reminder.usecases
+
+import com.example.domain.customer.CustomerId
+import com.example.domain.customer.NoteId
+import domain.reminder.Reminder
+import domain.reminder.ReminderId
+import domain.reminder.ReminderRepository
+import java.time.LocalDateTime
+
+class GetReminderUseCase(
+    private val reminderRepository: ReminderRepository
+) {
+    operator fun invoke(id: Long)
+    :Reminder? = reminderRepository.findById(ReminderId(id))
+
+}

--- a/src/test/kotlin/ApplicationTest.kt
+++ b/src/test/kotlin/ApplicationTest.kt
@@ -27,14 +27,14 @@ class ApplicationTest {
             contentType(ContentType.Application.Json)
             setBody("""
                 {
-                    "name": "John Doe",
-                    "email": "john@example.com"
+                    "name": "John Doe"
                 }
             """.trimIndent())
         }
         assertEquals(HttpStatusCode.Created, response.status)
         val responseBody = response.bodyAsText()
-        val customerId = Json.parseToJsonElement(responseBody).jsonObject["id"]?.jsonObject?.get("value")?.jsonPrimitive?.content
+        val customerId = Json.parseToJsonElement(responseBody).jsonObject["id"]?.jsonPrimitive?.content
+        println(customerId)
         assertNotNull(customerId)
 
         // Get customer
@@ -46,11 +46,7 @@ class ApplicationTest {
         client.post("/customers/$customerId/contacts") {
             contentType(ContentType.Application.Json)
             setBody("""
-                {
-                    "name": "Jane Doe",
-                    "email": "jane@example.com",
-                    "phone": "123-456-7890"
-                }
+              {"id":1,"name":"John Doe","email":"john@example.com","phone":"123-456-7890"}
             """.trimIndent())
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
@@ -60,9 +56,7 @@ class ApplicationTest {
         client.post("/customers/$customerId/notes") {
             contentType(ContentType.Application.Json)
             setBody("""
-                {
-                    "content": "Test note"
-                }
+                 { "id":  $customerId,"content": "test content $customerId" }
             """.trimIndent())
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
@@ -80,28 +74,25 @@ class ApplicationTest {
             contentType(ContentType.Application.Json)
             setBody("""
                 {
-                    "name": "John Doe",
-                    "email": "john@example.com"
+                    "name": "John Doe"
                 }
             """.trimIndent())
         }
-        val customerId = Json.parseToJsonElement(customerResponse.bodyAsText()).jsonObject["id"]?.jsonObject?.get("value")?.jsonPrimitive?.content
-        assertNotNull(customerId)
-
+        val customerId = Json.parseToJsonElement(customerResponse.bodyAsText()).jsonObject["id"]?.jsonPrimitive?.content
         // Create reminder
         val reminderResponse = client.post("/reminders") {
             contentType(ContentType.Application.Json)
             setBody("""
                 {
-                    "customerId": {"value": "$customerId"},
-                    "noteId": null,
-                    "remindAt": "2024-01-01T10:00:00",
-                    "message": "Test reminder"
+                  "customerId": $customerId,
+                  "noteId": null,
+                  "remindAt": "2025-05-04T15:30:00",
+                  "message": "Send invoice reminder."
                 }
             """.trimIndent())
         }
         assertEquals(HttpStatusCode.Created, reminderResponse.status)
-        val reminderId = Json.parseToJsonElement(reminderResponse.bodyAsText()).jsonObject["id"]?.jsonObject?.get("value")?.jsonPrimitive?.content
+        val reminderId =  Json.parseToJsonElement(reminderResponse.bodyAsText()).jsonObject["id"]?.jsonObject?.get("value")?.jsonPrimitive?.content
         assertNotNull(reminderId)
 
         // Get reminder


### PR DESCRIPTION
This PR refactors all use case classes to replace `operator fun invoke(...)` with a standard `execute(...)` function.

- Avoids promoting operator overloading without clear benefit, as suggested in the review.
- Updates service classes to explicitly call `.execute(...)` for clarity.
- While `invoke()` can simplify code when use cases are injected, in this structure explicit methods are clearer and more beginner-friendly.

Thanks for the earlier feedback — this should align better with clean DDD examples.
